### PR TITLE
Adds semantic-ui-react

### DIFF
--- a/src/main/cljsjs/semantic_ui_react.cljs
+++ b/src/main/cljsjs/semantic_ui_react.cljs
@@ -1,0 +1,5 @@
+(ns cljsjs.semantic-ui-react
+  (:require ["semantic-ui-react/dist/es/index.js" :as semantic-ui-react]))
+
+(js/goog.exportSymbol "semanticUIReact" semantic-ui-react)
+


### PR DESCRIPTION
For projects that use soda-ash, we need the `semanticUIReact` global
that cljsjs provides, instead of just relying directly on an
npm-installed version.

Note that brings in the ES module instead of the UMD like real cljsjs
does. The UMD fails with an (apparently) unsatisfiable dependency on
`ReactDOM` and was packaged with its own lodash, etc.