### PR TITLE
Create bindings for Vega and Vega-Lite

### DIFF
--- a/src/main/cljsjs/vega.cljs
+++ b/src/main/cljsjs/vega.cljs
@@ -1,0 +1,4 @@
+(ns cljsjs.vega
+  (:require ["vega" :as vega]))
+
+(js/goog.exportSymbol "vega" vega)

--- a/src/main/cljsjs/vega_embed.cljs
+++ b/src/main/cljsjs/vega_embed.cljs
@@ -1,0 +1,4 @@
+(ns cljsjs.vega-embed
+  (:require ["vega-embed" :as vega-embed]))
+
+(js/goog.exportSymbol "vegaEmbed" vega-embed)

--- a/src/main/cljsjs/vega_lite.cljs
+++ b/src/main/cljsjs/vega_lite.cljs
@@ -1,0 +1,4 @@
+(ns cljsjs.vega-lite
+  (:require ["vega-lite" :as vega-lite]))
+
+(js/goog.exportSymbol "vl" vega-lite)

--- a/src/main/cljsjs/vega_tooltip.cljs
+++ b/src/main/cljsjs/vega_tooltip.cljs
@@ -1,0 +1,4 @@
+(ns cljsjs.vega-tooltip
+  (:require ["vega-tooltip" :as vega-tooltip]))
+
+(js/goog.exportSymbol "vegaTooltip" vega-tooltip)


### PR DESCRIPTION
Basis for this PR is an attempt to use Shadow-CLJSJS to build a project that makes use of Oz. Oz uses Vega and Vega Lite for visualization. For more details, see the [issue][1]. Credit for this work is to @ivanminutillo.

@thheller, does this look right to you? I don't have a lot of Clojurescript experience, and I'd be happy to get a second pair of eyes.

[1]: https://github.com/metasoarous/oz/issues/64